### PR TITLE
Cleanup of setup.py for Mac

### DIFF
--- a/setup-mac.py
+++ b/setup-mac.py
@@ -4,8 +4,13 @@ from setuptools import setup, find_packages
 
 APP = ['run_cogstat_gui.py']
 APP_NAME = "CogStat"
-DATA_FILES = ['cogstat', 'README.md', 'cogstat.icns']
+DATA_FILES = ['cogstat/resources/cogstat.icns', 'README.md', 'LICENSE.txt', 'changelog.md']
 OPTIONS = {
+    'optimize': 2,
+    'semi_standalone': 'False',
+    'argv_emulation': 'False',
+    'site_packages': 'True',
+    'qt_plugins': ['sqldrivers'],
     'plist': {
         'CFBundleName': APP_NAME,
         'CFBundleDisplayName': APP_NAME,
@@ -17,9 +22,11 @@ OPTIONS = {
         'NSHumanReadableCopyright': "GNU GPL 3",
         'NSRequiresAquaSystemAppearance': 'YES',
         "LSApplicationCategoryType": 'public.app-category.education',
+        "NSPrincipalClass": 'NSApplication',
+        "NSHighResolutionCapable": 'True',
     }
     , 'packages': ['numpy', 'scipy', 'matplotlib',
-                        'pandas', 'statsmodels',
+                        'pandas', 'pandas_flavor', 'statsmodels',
                         'pyreadstat',  'xlrd', 'openpyxl', 'pyreadr',
                         'configobj',  'IPython', 'Jupyter',
                         'pingouin', 'python-bidi', 'odfpy', 'scikit-posthocs',
@@ -38,5 +45,6 @@ setup(
     author_email='krajcsi@gmail.com',
     include_package_data=True,
     setup_requires=['py2app'],
-    python_requires='>=3.6'
+    python_requires='>=3.6',
+    packages = find_packages(),
 )


### PR DESCRIPTION
– No need to include cogstat source folder as datafile, as source code gets picked up by py2app to python lib anyway
– pandas_flavor needs to be specifically called out
– options added to config to simplify compilation running from terminal