### PR TITLE
Fixes svg rendering on Mac

### DIFF
--- a/cogstat/cogstat_gui.py
+++ b/cogstat/cogstat_gui.py
@@ -12,6 +12,7 @@ from PyQt5 import QtGui, QtWidgets
 from PyQt5.QtCore import Qt
 
 app = QtWidgets.QApplication(sys.argv)
+app.setAttribute(Qt.AA_UseHighDpiPixmaps)
 pixmap = QtGui.QPixmap(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources',
                                     'CogStat splash screen.png'), 'PNG')
 splash_screen = QtWidgets.QSplashScreen(pixmap)


### PR DESCRIPTION
Updating cogstat_gui.py by telling PyQt5 to render svg in high DPI to fix svg rendering issues (pixelation) on Mac devices.