### PR TITLE
Image processing change from QImage to PNG

### DIFF
--- a/cogstat/cogstat_gui.py
+++ b/cogstat/cogstat_gui.py
@@ -20,6 +20,9 @@ splash_screen = QtWidgets.QSplashScreen(pixmap)
 splash_screen.show()
 splash_screen.showMessage('', Qt.AlignBottom, Qt.white)  # TODO find something else to make the splash visible
 
+screen = app.screens()[0]
+physicaldpi = screen.physicalDotsPerInch()
+
 # go on with regular imports, etc.
 from distutils.version import LooseVersion
 import gettext

--- a/cogstat/cogstat_util.py
+++ b/cogstat/cogstat_util.py
@@ -180,7 +180,7 @@ def convert_output(outputs):
     rcParams['figure.dpi'] = gui.physicaldpi * gui.app.devicePixelRatio()
 
     def _figure_to_qimage(figure):
-        """Convert matplotlib figure to pyqt qImage.
+        """Convert matplotlib figure to image file.
 
         Parameters
         ----------
@@ -188,7 +188,7 @@ def convert_output(outputs):
 
         Returns
         -------
-        qImage
+        PNG
         """
         import base64
         import io


### PR DESCRIPTION
- Changes image processing from QImage to PNG when placing in the result set html/iPython.

- This change is the pre-requisite for exporting results as a self-contained html