### PR TITLE
Allowing for saving results as HTML files

### DIFF
--- a/cogstat/cogstat_dialogs.py
+++ b/cogstat/cogstat_dialogs.py
@@ -60,7 +60,7 @@ def open_demo_data_file(directory):
 
 def save_output():
     return str(QtWidgets.QFileDialog.getSaveFileName(None, _('Save result file'), 'CogStat analysis result.pdf',
-                                                     '*.pdf')[0])
+                                                     '*.pdf, *.html')[0])
 
 # XXX self.buttonBox.Ok.setEnabled(False) # TODO how can we disable the OK button without the other?
 # TODO Some variables are CamelCase - change them

--- a/cogstat/cogstat_gui.py
+++ b/cogstat/cogstat_gui.py
@@ -955,11 +955,24 @@ class StatMainWindow(QtWidgets.QMainWindow):
         if not filename:
             filename = cogstat_dialogs.save_output()
         self.output_filename = filename
-        if filename:
+        if filename[:-4]==".pdf":
             pdf_printer = QtPrintSupport.QPrinter()
             pdf_printer.setOutputFormat(QtPrintSupport.QPrinter.PdfFormat)
             pdf_printer.setOutputFileName(self.output_filename)
             self.output_pane.print_(pdf_printer)
+            self.unsaved_output = False
+        else:
+            # Save output as html file
+            if filename[:-5]==".html":
+                html_filename = filename
+            else:
+                html_filename = filename[:-4] + '.html'
+            html_file = self.output_pane.toHtml()
+            # replace non-breaking spaces with html code for non-breaking spaces
+            html_file = html_file.replace(' ', '&nbsp;')
+            
+            with open(html_filename, 'w') as f:
+                f.write(html_file)
             self.unsaved_output = False
 
     ### Cogstat menu  methods ###

--- a/cogstat/cogstat_gui.py
+++ b/cogstat/cogstat_gui.py
@@ -20,6 +20,9 @@ splash_screen = QtWidgets.QSplashScreen(pixmap)
 splash_screen.show()
 splash_screen.showMessage('', Qt.AlignBottom, Qt.white)  # TODO find something else to make the splash visible
 
+screen = app.screens()[0]
+physicaldpi = screen.physicalDotsPerInch()
+
 # go on with regular imports, etc.
 from distutils.version import LooseVersion
 import gettext


### PR DESCRIPTION
What this PR does is:
- Adds .html as acceptable file type when saving result set
- Changes save as procedure allowing for html export (contains adjustment for non-break space)

This pull request contains image method change #212 !