### PR TITLE
Update setup-mac.py

### DIFF
--- a/setup-mac.py
+++ b/setup-mac.py
@@ -16,8 +16,8 @@ OPTIONS = {
         'CFBundleDisplayName': APP_NAME,
         'CFBundleGetInfoString': "Simple statistics for researchers.",
         'CFBundleIdentifier': "com.cogstat.org.cogstat",
-        'CFBundleVersion': "2.3rc",
-        'CFBundleShortVersionString': "2.3rc",
+        'CFBundleVersion': "2.4beta",
+        'CFBundleShortVersionString': "2.4beta",
         'CFBundleIconFile': "cogstat.icns",
         'NSHumanReadableCopyright': "GNU GPL 3",
         'NSRequiresAquaSystemAppearance': 'YES',
@@ -28,7 +28,7 @@ OPTIONS = {
     , 'packages': ['numpy', 'scipy', 'matplotlib',
                         'pandas', 'pandas_flavor', 'statsmodels',
                         'pyreadstat',  'xlrd', 'openpyxl', 'pyreadr',
-                        'configobj',  'IPython', 'Jupyter',
+                        'configobj',  'chardet', 'IPython', 'Jupyter',
                         'pingouin', 'python-bidi', 'odfpy', 'scikit-posthocs',
                         ]
 }
@@ -38,7 +38,7 @@ setup(
     app=APP,
     data_files=DATA_FILES,
     options={'py2app': OPTIONS},
-    version='2.3rc',
+    version='2.4beta',
     description='Simple statistics for researchers.',
     url='https://www.cogstat.org',
     author='Attila Krajcsi',


### PR DESCRIPTION
configobj and chardet have to be specified, otherwise they won't get added by py2app and they have to be in the requirements.txt as well or installed through pip3 manually, otherwise won't compile and run